### PR TITLE
25 acquisition progress

### DIFF
--- a/control/src/hexitec/acquisition/controller.py
+++ b/control/src/hexitec/acquisition/controller.py
@@ -155,3 +155,6 @@ class AcquisitionController(BaseController):
     def cleanup(self):
         """Clean up controller resources."""
         logging.debug("Cleaning up AcquisitionController")
+        # Stop background task
+        self.state.acquisition_progress_task_enable = False
+        logging.debug(f"Stopped acquisition progress task")

--- a/control/src/hexitec/acquisition/controller.py
+++ b/control/src/hexitec/acquisition/controller.py
@@ -68,7 +68,7 @@ class AcquisitionController(BaseController):
             )
         
         if 'sequencer' in self.adapters:
-            logging.debug("Acquisition controller registering context with sequencer")
+            logging.debug("Acquisition controller registering contexts with sequencer")
             self.adapters['sequencer'].add_context('acquisition', self)
             self.adapters['sequencer'].add_context('monitor', self.hexitec.controller)
             self.adapters['sequencer'].add_context('liveview', self.liveview.controller)

--- a/control/src/hexitec/acquisition/controller.py
+++ b/control/src/hexitec/acquisition/controller.py
@@ -73,8 +73,8 @@ class AcquisitionController(BaseController):
 
         # Provide adapters to sub-processess
 
-        self.configuration = Configuration(self.adapters, AcquisitionError)
-        self.state = State(self.adapters, AcquisitionError)
+        self.configuration = Configuration(self.adapters, self.munir_subsystem, AcquisitionError)
+        self.state = State(self.adapters, self.munir_subsystem, AcquisitionError)
 
         self.state._register_configuration(self.configuration)
         self.configuration._register_state(self.state)

--- a/control/src/hexitec/acquisition/controller.py
+++ b/control/src/hexitec/acquisition/controller.py
@@ -66,6 +66,16 @@ class AcquisitionController(BaseController):
                 f"Could not find munir subsystem '{self.munir_subsystem}' in available managers: "
                 f"{list(self.munir.controller.munir_managers.keys())}"
             )
+        
+        if 'sequencer' in self.adapters:
+            logging.debug("Acquisition controller registering context with sequencer")
+            self.adapters['sequencer'].add_context('acquisition', self)
+            self.adapters['sequencer'].add_context('monitor', self.hexitec.controller)
+            self.adapters['sequencer'].add_context('liveview', self.liveview.controller)
+            self.adapters['sequencer'].add_context('histogram', self.histogrammer.controller)
+            self.adapters['sequencer'].add_context('munir', self.munir.controller)
+            self.adapters['sequencer'].add_context('proxy', self.proxy)
+            self.adapters['sequencer'].add_context('readout', self.readout.controller)
 
         # Set a default file name and path
         iac_set(self.munir, f"subsystems/{self.munir_subsystem}/args/file_path", self.options.get('default_filepath', '/tmp/'))

--- a/control/src/hexitec/acquisition/processes/configuration.py
+++ b/control/src/hexitec/acquisition/processes/configuration.py
@@ -55,8 +55,7 @@ class Configuration():
                 'number_of_timeframes': (lambda: self.number_of_timeframes, self.set_number_of_timeframes,
                                          {'min': 1}),
                 'timeframes_per_trigger': (lambda: self.timeframes_per_trigger, self.set_timeframes_per_trigger,
-                                           {'min': 1}),
-                'configure_histogramming': (lambda: None, self._configure_histogramming)
+                                           {'min': 1})
             },
             'baseline': {
                 'toggle': (lambda: self.baseline_settings['enabled'], self.toggle_baseline)
@@ -225,9 +224,9 @@ class Configuration():
         num_bins = bin_mode.split('_')[-1]
         # Data rate is hists/second * size per hist / 1_000_000_000 for GB/s
         # hists_per_second is 1M (frames per second) divided by frames per hist
-        hists_per_second = 1_000_000 // self.frames_per_timeframe
+        hists_per_second = 1_000_000 / self.frames_per_timeframe
         data_rate = hists_per_second * (80*80*int(num_bins)*4) / 1_000_000_000
-        self.data_rate = data_rate
+        self.data_rate = round(data_rate, 4)
         return self.data_rate
 
     def toggle_baseline(self, value: bool):

--- a/control/src/hexitec/acquisition/processes/configuration.py
+++ b/control/src/hexitec/acquisition/processes/configuration.py
@@ -2,7 +2,6 @@
 from odin.adapters.parameter_tree import ParameterTree, ParameterTreeError
 import logging
 from hexitec.util.iac import iac_get, iac_set
-
 class Configuration():
     def __init__(self, adapters, AcquisitionError):
         self.bin_mode = "histogram_1024"
@@ -14,10 +13,19 @@ class Configuration():
 
         self.AcquisitionError = AcquisitionError
 
-        self.device = "software"
-        self.trigger_mode = "burst"
-        self.frames_per_timeframe = 200000
-        self.number_of_timeframes = 20
+        self.device_options = ["software", "hardware"]
+
+        # Get system to a known state on start
+        # iac_get are safe here as this is part of acquisition adapter's initialize
+        using_hardware = iac_get(self.readout, "trigger/enable")
+        self.device = "hardware" if using_hardware else "software"
+
+        self.trigger_mode = iac_get(self.readout, "trigger/mode")
+
+        self.frames_per_timeframe = int(iac_get(self.histogrammer, "acquisition/input_frames"))
+        self.number_of_timeframes = int(iac_get(self.histogrammer, "acquisition/output_frames"))
+        self.timeframes_per_trigger = int(iac_get(self.readout, "trigger/frame_limits/hist_in_trigger"))
+
         self.data_rate = self.calculate_estimated_data_rate()
 
         # There is no true 'on/off' setting for this, but a set of commands that do about the same
@@ -37,13 +45,15 @@ class Configuration():
                         }),
             'trigger': {
                 'device': (lambda: self.device, self.set_device,
-                           {'allowed_values': ["software", "hardware"]}),
+                           {'allowed_values': self.device_options}),
                 'trigger_mode': (lambda: self.trigger_mode, self.change_trigger_mode, 
-                                 {'allowed_values': ["burst", "step_scan", "continuous"]}),
+                                 {'allowed_values': ["burst mode", "step scan", "continuous mode"]}),
                 'frames_per_timeframe': (lambda: self.frames_per_timeframe, self.set_frames_per_timeframe,
                                          {'min': 1}),
                 'number_of_timeframes': (lambda: self.number_of_timeframes, self.set_number_of_timeframes,
                                          {'min': 1}),
+                'timeframes_per_trigger': (lambda: self.timeframes_per_trigger, self.set_timeframes_per_trigger,
+                                           {'min': 1}),
                 'configure_histogramming': (lambda: None, self._configure_histogramming)
             },
             'baseline': {
@@ -53,7 +63,7 @@ class Configuration():
         })
 
     def _register_state(self, state):
-        """Get a reference to the configuration class."""
+        """Get a reference to the state class."""
         self.state = state
 
     def change_bin_mode(self, bin_mode: str):
@@ -116,13 +126,23 @@ class Configuration():
         """Set the trigger device, which may be software or hardware
         :param device: string representing the trigger device, either 'software' or 'hardware'
         """
+        device = device.lower()
+        if device in self.device_options:
+            if device == "software":
+                iac_set(self.readout, "trigger/enable", False)
+                iac_set(self.histogrammer, "acquisition/mode", "count frames")
+            elif device == "hardware":
+               iac_set(self.readout, "trigger/enable", True)
+               iac_set(self.histogrammer, "acquisition/mode", "continuous")
+
         self.device = device
 
     def change_trigger_mode(self, mode: str):
         """Set the trigger mode, used for hardware triggering.
-        :param mode: string representing the trigger mode, either 'burst', 'step_scan', or 'continuous'
+        :param mode: string representing the trigger mode, either 'burst mode', 'step scan', or 'continuous mode'
         """
         self.trigger_mode = mode
+        iac_set(self.readout, "trigger/mode", mode)
 
     def set_frames_per_timeframe(self, frames: int):
         """Set the number of frames per timeframe/histogram.
@@ -150,7 +170,14 @@ class Configuration():
         if frames < min_frames_per_timeframe:
             raise self.AcquisitionError(f"Frames per timeframe must be at least {min_frames_per_timeframe}.")
 
-        self.frames_per_timeframe = frames
+        try:
+            # Software, internal timeframe generator
+            iac_set(self.histogrammer, "acquisition/input_frames", frames)
+            # Hardware, on trigger received
+            iac_set(self.readout, "trigger/frame_limits/frame_in_hist", frames)
+            self.frames_per_timeframe = frames
+        except Exception as err:
+            logging.warning(f"Could not set frames per timeframe: {err}")
 
         self.calculate_estimated_data_rate()
 
@@ -164,46 +191,29 @@ class Configuration():
 
     def set_number_of_timeframes(self, timeframes: int):
         """Set the number of timeframes to be acquired.
-        How this is interpreted depends on the mode:
-            - Software: number of timeframes before no new ones are sent out
-            - Hardware/burst: number of timeframes to be captured per trigger
-        This value is not used in continuous mode. In step scan mode it is 1 (value not changed).
-        :param timeframes: positive integer representing the number of timeframes
+        Not all the values set will be used each time, depending on hardware/software mode.
+        :param timeframes: integer representing timeframes to be captured duing acquisition
         """
-        if timeframes < 1:
-            raise self.AcquisitionError("Number of timeframes must be a positive integer.")
-        self.number_of_timeframes = timeframes
+        try:
+            # Frame target for acquisition
+            iac_set(self.munir, "subsystems/hexitec_mhz/args/num_frames", timeframes)
+            # Software, internal timeframe generator. Not used in this way for 
+            iac_set(self.histogrammer, "acquisition/output_frames", timeframes)
+            self.number_of_timeframes = timeframes
+        except Exception as err:
+            logging.warning(f"Could not set number of timeframes: {err}")
 
-
-    def _configure_histogramming(self):
-        """Configure histogrammer and munir depending on the operating mode of the detector.
-        The same parameters are used for each but interpreted differently depending on the mode.
+    def set_timeframes_per_trigger(self, timeframes: int):
+        """Set the number of timeframes per trigger.
+        This is only used in burst mode with hardware capturing.
+        :param timeframes: integer representing the number of timeframes per trigger
         """
-        def use_hardware(cls: Configuration, mode: str):
-            iac_set(cls.munir, "subsystems/hexitec_mhz/args/num_frames", 0)
-            iac_set(cls.readout, "trigger/enable", True)
-            iac_set(cls.readout, "trigger/mode", mode)
-            iac_set(cls.histogrammer, "acquisition/mode", "continuous")
-
-        match (self.device, self.trigger_mode):
-            case ("software", _):
-                # Software: alveo module configured with frames per timeframe and number of timeframes
-                iac_set(self.histogrammer, "acquisition/mode", "count frames")
-                iac_set(self.munir, "subsystems/hexitec_mhz/args/num_frames", self.number_of_timeframes)
-                iac_set(self.histogrammer, "acquisition/input_frames", self.frames_per_timeframe)
-                iac_set(self.histogrammer, "acquisition/output_frames", self.number_of_timeframes)
-            case ("hardware", "burst"):
-                # Burst: X frames per timeframe, Y timeframes per trigger
-                use_hardware(self, "burst mode")
-                iac_set(self.readout, "trigger/frame_limits/frame_in_hist", self.frames_per_timeframe)
-                iac_set(self.readout, "trigger/frame_limits/hist_in_trigger", self.number_of_timeframes)
-            case ("hardware", "step_scan"):
-                # Step scan: one timeframe pre trigger, X frames per timeframe
-                use_hardware(self, "step scan")
-                iac_set(self.readout, "trigger/frame_limits/frame_in_hist", self.frames_per_timeframe)
-            case ("hardware", "continuous"):
-                # Continuous: write frames to a timeframe until another trigger is fired
-                use_hardware(self, "continuous mode")
+        try:
+            # Hardware
+            iac_set(self.readout, "trigger/frame_limits/hist_in_trigger", timeframes)
+            self.timeframes_per_trigger = timeframes
+        except Exception as err:
+            logging.warning(f"Could not set timeframes per trigger: {err}")
 
     def calculate_estimated_data_rate(self):
         """Calculate the estimated data rate based on the current configuration."""

--- a/control/src/hexitec/acquisition/processes/configuration.py
+++ b/control/src/hexitec/acquisition/processes/configuration.py
@@ -3,10 +3,12 @@ from odin.adapters.parameter_tree import ParameterTree, ParameterTreeError
 import logging
 from hexitec.util.iac import iac_get, iac_set
 class Configuration():
-    def __init__(self, adapters, AcquisitionError):
+    def __init__(self, adapters, munir_subsystem, AcquisitionError):
+        self.munir_subsystem = munir_subsystem
+
         self.bin_mode = "histogram_1024"
         self.munir = adapters["munir"]
-        self.munir_odindata_controller = self.munir.controller.munir_managers['hexitec_mhz'].odin_data_instances[0]  # Only anticipate one odin data instance for now
+        self.munir_odindata_controller = self.munir.controller.munir_managers[self.munir_subsystem].odin_data_instances[0]  # Only anticipate one odin data instance for now
         self.histogrammer = adapters["histogram"]
         self.readout = adapters["readout"]
         self.liveview = adapters["liveview"]
@@ -86,9 +88,9 @@ class Configuration():
                 hist_value='1024'
 
         # Stop odin-data
-        if self.munir.controller.execute_flags['hexitec_mhz']:
+        if self.munir.controller.execute_flags[self.munir_subsystem]:
             was_executing = True
-            iac_set(self.munir, 'execute/hexitec_mhz', False)
+            iac_set(self.munir, f'execute/{self.munir_subsystem}', False)
 
         # Disable histogrammer
         iac_set(self.histogrammer, "acquisition/run", False)
@@ -120,7 +122,7 @@ class Configuration():
         # Restart liveview if it was running
         if was_executing:
             iac_set(self.histogrammer, "acquisition/run", True)
-            iac_set(self.munir, 'execute/hexitec_mhz', True)
+            iac_set(self.munir, f'execute/{self.munir_subsystem}', True)
 
     def set_device(self, device: str):
         """Set the trigger device, which may be software or hardware
@@ -196,7 +198,7 @@ class Configuration():
         """
         try:
             # Frame target for acquisition
-            iac_set(self.munir, "subsystems/hexitec_mhz/args/num_frames", timeframes)
+            iac_set(self.munir, f"subsystems/{self.munir_subsystem}/args/num_frames", timeframes)
             # Software, internal timeframe generator. Not used in this way for 
             iac_set(self.histogrammer, "acquisition/output_frames", timeframes)
             self.number_of_timeframes = timeframes

--- a/control/src/hexitec/acquisition/processes/configuration.py
+++ b/control/src/hexitec/acquisition/processes/configuration.py
@@ -124,6 +124,8 @@ class Configuration():
             iac_set(self.histogrammer, "acquisition/run", True)
             iac_set(self.munir, f'execute/{self.munir_subsystem}', True)
 
+        self.calculate_estimated_data_rate()
+
     def set_device(self, device: str):
         """Set the trigger device, which may be software or hardware
         :param device: string representing the trigger device, either 'software' or 'hardware'

--- a/control/src/hexitec/acquisition/processes/state.py
+++ b/control/src/hexitec/acquisition/processes/state.py
@@ -42,6 +42,10 @@ class State():
             },
         })
 
+    def set_progress_task_interval(self, time: float):
+        """Set the acquisition progress task update rate."""
+        self.acquisition_progress_task_interval = time
+
     def _register_configuration(self, configuration):
         """Get a reference to the configuration class."""
         self.configuration = configuration

--- a/control/src/hexitec/acquisition/processes/state.py
+++ b/control/src/hexitec/acquisition/processes/state.py
@@ -72,8 +72,10 @@ class State():
 
     def _stop_preview(self):
         """Stops the preview mode, returning the system to an idle state."""
-        # Stop histogrammer
         iac_set(self.histogrammer, "acquisition/run", False)
+        # Reset histogram settings
+        iac_set(self.histogrammer, "acquisition/input_frames", self.configuration.frames_per_timeframe)
+        iac_set(self.histogrammer, "acquisition/output_frames", self.configuration.number_of_timeframes)
         iac_set(self.munir, f"subsystems/{self.munir_subsystem}", {"stop_execute": True})
 
     def set_preview_frames_per_hist(self, frames):
@@ -159,7 +161,8 @@ class State():
     def acquisition_progress_task(self):
         while self.acquisition_progress_task_enable:
             while self.acquisition_progress < 100:
-                frames_received = iac_get(self.munir, f"subsystems/{self.munir_subsystem}/status/frames_written")
+                munir_status = iac_get(self.munir, f"subsystems/{self.munir_subsystem}/status/")
+                frames_received = munir_status[0].get("hdf", {}).get("frames_written", 0)
                 self.acquisition_progress = round((frames_received / self.configuration.number_of_timeframes) * 100, 2)
             else:
                 # Acquisition complete, disable this task and stop the acquisition

--- a/control/src/hexitec/acquisition/processes/state.py
+++ b/control/src/hexitec/acquisition/processes/state.py
@@ -4,10 +4,14 @@ import logging
 from hexitec.util.iac import iac_get, iac_set
 import time
 
+from tornado.concurrent import run_on_executor
+
 class State():
-    def __init__(self, adapters, AcquisitionError):
+    def __init__(self, adapters, munir_subsystem, AcquisitionError):
+        self.munir_subsystem = munir_subsystem
+
         self.munir = adapters["munir"]
-        self.munir_odindata_controller = self.munir.controller.munir_managers['hexitec_mhz'].odin_data_instances[0]  # Only anticipate one odin data instance for now
+        self.munir_odindata_controller = self.munir.controller.munir_managers[self.munir_subsystem].odin_data_instances[0]  # Only anticipate one odin data instance for now
         self.histogrammer = adapters["histogram"]
         self.readout = adapters["readout"]
         self.liveview = adapters["liveview"]
@@ -20,14 +24,22 @@ class State():
         self.preview_frames_per_hist = 1000000
         self.is_acquiring = False
 
+        self.acquisition_progress_task_enable = False
+        self.acquisition_progress_task_interval = 0.5
+        self.acquisition_progress = 0.0
+
         self.tree = ParameterTree({
             'preview': {
                 'toggle': (lambda: self.is_previewing, self.toggle_preview),
                 'frames_per_hist': (lambda: self.preview_frames_per_hist, self.set_preview_frames_per_hist)
             },
             'acquisition': {
-                'toggle': (lambda: self.is_acquiring, self.toggle_acquisition)
-            }
+                'toggle': (lambda: self.is_acquiring, self.toggle_acquisition),
+                "progress_task": {
+                    "interval": (lambda: self.acquisition_progress_task_interval, self.set_progress_task_interval),
+                    "progress": (lambda: self.acquisition_progress, None)
+                }
+            },
         })
 
     def _register_configuration(self, configuration):
@@ -47,7 +59,7 @@ class State():
 
     def _start_preview(self):
         """Starts 'preview mode', which runs the histogrammer through software and saves no data."""
-        iac_set(self.munir, "subsystems/hexitec_mhz", {"start_lv_frames": True})
+        iac_set(self.munir, f"subsystems/{self.munir_subsystem}", {"start_lv_frames": True})
 
         iac_set(self.histogrammer, "acquisition/mode", "count frames")
         iac_set(self.histogrammer, "acquisition/output_frames", 20_000_000)
@@ -58,7 +70,7 @@ class State():
         """Stops the preview mode, returning the system to an idle state."""
         # Stop histogrammer
         iac_set(self.histogrammer, "acquisition/run", False)
-        iac_set(self.munir, "subsystems/hexitec_mhz", {"stop_execute": True})
+        iac_set(self.munir, f"subsystems/{self.munir_subsystem}", {"stop_execute": True})
 
     def set_preview_frames_per_hist(self, frames):
         """Set the number of frames per histogram for preview mode.
@@ -102,26 +114,30 @@ class State():
         try:
             num_bins = iac_get(self.histogrammer, "config/hist_format/num_bins")
             num_bins = "histogram_" + str(num_bins)
-            munir_mode = iac_get(self.munir, "subsystems/hexitec_mhz/frame_procs/status")
+            munir_mode = iac_get(self.munir, f"subsystems/{self.munir_subsystem}/frame_procs/status")
             munir_mode = str(munir_mode[0].get("HexitecMhz", {}).get("mode", ""))
             logging.warning(f"Checking modes before acquisition: histogrammer num_bins={num_bins}, munir mode={munir_mode}")
-            # munir_mode = iac_get(self.munir, "subsystems/hexitec_mhz/frame_procs/status/HexitecMhz/mode")
+            # munir_mode = iac_get(self.munir, f"subsystems/{self.munir_subsystem}/frame_procs/status/HexitecMhz/mode")
         except Exception as error:
             logging.error(f"Error checking modes before acquisition: {error}")
             raise self.AcquisitionError(f"Error checking modes before acquisition: {error}")
         if num_bins != munir_mode:
             logging.warning(f"Histogrammer num_bins {num_bins} does not match munir mode {munir_mode}. Changing bin modes to match histogrammer.")
             self.configuration.change_bin_mode(num_bins)
-            while iac_get(self.munir, "subsystems/hexitec_mhz/frame_procs/status/HexitecMhz/mode") != num_bins:
+            while iac_get(self.munir, f"subsystems/{self.munir_subsystem}/frame_procs/status/HexitecMhz/mode") != num_bins:
                 logging.warning(f"Waiting for odin data to reconfigure to new bin mode...")
                 time.sleep(0.5)
 
         # Start listening for data
-        iac_set(self.munir, "execute", {'hexitec_mhz': True})
+        iac_set(self.munir, "execute", {self.munir_subsystem: True})
 
         # Configure how data should be sent
-        iac_set(self.munir, "subsystems/hexitec_mhz/args/num_frames", self.configuration.number_of_timeframes)
+        iac_set(self.munir, f"subsystems/{self.munir_subsystem}/args/num_frames", self.configuration.number_of_timeframes)
         iac_set(self.histogrammer, "acquisition/run", True)
+
+        # This task runs in the thread execution pool
+        self.acquisition_progress_task_enable = True
+        self.acquisition_progress_task()
 
     def _stop_acquisition(self):
         self.is_acquiring = False
@@ -130,7 +146,22 @@ class State():
         iac_set(self.readout, "trigger/enable", False)
 
         iac_set(self.histogrammer, "acquisition/run", False)
-        iac_set(self.munir, "subsystems/hexitec_mhz/stop_execute", False)
+        iac_set(self.munir, f"subsystems/{self.munir_subsystem}/stop_execute", False)
 
         if self.was_previewing:
             self.toggle_preview(True)
+
+    @run_on_executor
+    def acquisition_progress_task(self):
+        while self.acquisition_progress_task_enable:
+            while self.acquisition_progress < 100:
+                frames_received = iac_get(self.munir, f"subsystems/{self.munir_subsystem}/status/frames_written")
+                self.acquisition_progress = round((frames_received / self.configuration.number_of_timeframes) * 100, 2)
+            else:
+                # Acquisition complete, disable this task and stop the acquisition
+                self.acquisition_progress_task_enable = False
+                self._stop_acquisition()
+        
+            time.sleep(self.acquisition_progress_task_interval)
+        
+        logging.debug("Stopping acquisition progress background task.")

--- a/control/src/hexitec/acquisition/processes/state.py
+++ b/control/src/hexitec/acquisition/processes/state.py
@@ -3,6 +3,7 @@ from odin.adapters.parameter_tree import ParameterTree, ParameterTreeError
 import logging
 from hexitec.util.iac import iac_get, iac_set
 import time
+from datetime import datetime
 
 from tornado.concurrent import run_on_executor
 
@@ -28,6 +29,11 @@ class State():
         self.acquisition_progress_task_interval = 0.5
         self.acquisition_progress = 0.0
 
+        # File settings (as convenience functions for munir)
+        self.file_name = "mhz_acquisition"
+        self.file_path = "/tmp"
+        self.file_timestamp = False
+
         self.tree = ParameterTree({
             'preview': {
                 'toggle': (lambda: self.is_previewing, self.toggle_preview),
@@ -38,9 +44,34 @@ class State():
                 "progress_task": {
                     "interval": (lambda: self.acquisition_progress_task_interval, self.set_progress_task_interval),
                     "progress": (lambda: self.acquisition_progress, None)
-                }
-            },
+                },
+                'file_name': (lambda: self.file_name, self.set_file_name),
+                'file_path': (lambda: self.file_path, self.set_file_path),
+                'add_timestamp': (lambda: self.file_timestamp, self.toggle_file_timestamp)
+            }
         })
+
+    def set_file_name(self, filename: str):
+        """Set the name of the file to be saved through munir arguments.
+        :param filename: string representing the name of the file
+        """
+        iac_set(self.munir, f"subsystems/{self.munir_subsystem}/args/file_name", filename)
+        self.filename = filename
+
+    def set_file_path(self, filepath: str):
+        """Set the path that the file is to be saved to through munir arguments.
+        :param filepath: string representing the filepath
+        """
+        iac_set(self.munir, f"subsystems/{self.munir_subsystem}/args/file_path", filepath)
+        self.filepath = filepath
+
+    def toggle_file_timestamp(self, enable: bool):
+        """Set the file timestamp toggle to True or False.
+        This adds a timestamp to the name of the file at time of acquisition start.
+        The format is: _YYMMDD_HHMMSS 
+        :param enable: boolean representing the state of the toggle
+        """
+        self.file_timestamp = bool(enable)
 
     def set_progress_task_interval(self, time: float):
         """Set the acquisition progress task update rate."""
@@ -133,6 +164,14 @@ class State():
             while iac_get(self.munir, f"subsystems/{self.munir_subsystem}/frame_procs/status/HexitecMhz/mode") != num_bins:
                 logging.warning(f"Waiting for odin data to reconfigure to new bin mode...")
                 time.sleep(0.5)
+
+        # Timestamp
+        if self.file_timestamp:
+            filename = iac_get(self.munir, f"subsystems/{self.munir_subsystem}/args/file_name")
+            stamp = datetime.now().strftime('%y%m%d_%H%M%S')
+            filename = filename + "_" + stamp
+            self.file_name = filename
+            iac_set(self.munir, f"subsystems/{self.munir_subsystem}/args/file_name", self.file_name)
 
         # Configure how data should be sent
         iac_set(self.munir, f"subsystems/{self.munir_subsystem}/args/num_frames", self.configuration.number_of_timeframes)

--- a/control/src/hexitec/acquisition/processes/state.py
+++ b/control/src/hexitec/acquisition/processes/state.py
@@ -6,8 +6,12 @@ import time
 from datetime import datetime
 
 from tornado.concurrent import run_on_executor
+from concurrent import futures
 
 class State():
+
+    executor = futures.ThreadPoolExecutor(max_workers=1)
+
     def __init__(self, adapters, munir_subsystem, AcquisitionError):
         self.munir_subsystem = munir_subsystem
 
@@ -56,14 +60,14 @@ class State():
         :param filename: string representing the name of the file
         """
         iac_set(self.munir, f"subsystems/{self.munir_subsystem}/args/file_name", filename)
-        self.filename = filename
+        self.file_name = filename
 
     def set_file_path(self, filepath: str):
         """Set the path that the file is to be saved to through munir arguments.
         :param filepath: string representing the filepath
         """
         iac_set(self.munir, f"subsystems/{self.munir_subsystem}/args/file_path", filepath)
-        self.filepath = filepath
+        self.file_path = filepath
 
     def toggle_file_timestamp(self, enable: bool):
         """Set the file timestamp toggle to True or False.
@@ -131,6 +135,7 @@ class State():
             self._stop_acquisition()
 
     def _start_acquisition(self):
+
         
         # First, check if acquisition can work with data rate
         data_rate = self.configuration.calculate_estimated_data_rate()
@@ -141,6 +146,7 @@ class State():
             return
 
         self.is_acquiring = True
+        self.acquisition_progress = 0
 
         if self.is_previewing:
             self.toggle_preview(False)
@@ -170,8 +176,8 @@ class State():
             filename = iac_get(self.munir, f"subsystems/{self.munir_subsystem}/args/file_name")
             stamp = datetime.now().strftime('%y%m%d_%H%M%S')
             filename = filename + "_" + stamp
-            self.file_name = filename
-            iac_set(self.munir, f"subsystems/{self.munir_subsystem}/args/file_name", self.file_name)
+            # self.file_name = filename
+            iac_set(self.munir, f"subsystems/{self.munir_subsystem}/args/file_name", filename)
 
         # Configure how data should be sent
         iac_set(self.munir, f"subsystems/{self.munir_subsystem}/args/num_frames", self.configuration.number_of_timeframes)
@@ -185,6 +191,7 @@ class State():
         self.acquisition_progress_task()
 
     def _stop_acquisition(self):
+        self.acquisition_progress_task_enable = False  # Stopping manually also must stop background
         self.is_acquiring = False
 
         # Back to software for the purpose of previewing
@@ -199,15 +206,21 @@ class State():
     @run_on_executor
     def acquisition_progress_task(self):
         while self.acquisition_progress_task_enable:
-            while self.acquisition_progress < 100:
-                munir_status = iac_get(self.munir, f"subsystems/{self.munir_subsystem}/status/")
-                frames_received = munir_status[0].get("hdf", {}).get("frames_written", 0)
-                self.acquisition_progress = round((frames_received / self.configuration.number_of_timeframes) * 100, 2)
-            else:
+            munir_status = iac_get(self.munir, f"subsystems/{self.munir_subsystem}/frame_procs/status")
+            frames_received = munir_status[0].get("hdf", {}).get("frames_written", 0)
+            frames_received += 1  # n-1 bug in histogrammer
+
+            self.acquisition_progress = round((frames_received / self.configuration.number_of_timeframes) * 100, 2)
+
+            if self.acquisition_progress >= 100:
+                # Force a wait of ~1 frame's worth of time to ensure synchronicity
+                wait = self.configuration.frames_per_timeframe / 1_000_000
+                wait = 5 if wait > 5 else wait  # Upper limit on the wait
+                time.sleep(wait)
                 # Acquisition complete, disable this task and stop the acquisition
                 self.acquisition_progress_task_enable = False
                 self._stop_acquisition()
-        
+
             time.sleep(self.acquisition_progress_task_interval)
         
         logging.debug("Stopping acquisition progress background task.")

--- a/control/src/hexitec/acquisition/processes/state.py
+++ b/control/src/hexitec/acquisition/processes/state.py
@@ -128,11 +128,11 @@ class State():
                 logging.warning(f"Waiting for odin data to reconfigure to new bin mode...")
                 time.sleep(0.5)
 
-        # Start listening for data
-        iac_set(self.munir, "execute", {self.munir_subsystem: True})
-
         # Configure how data should be sent
         iac_set(self.munir, f"subsystems/{self.munir_subsystem}/args/num_frames", self.configuration.number_of_timeframes)
+
+        # Start listening for data
+        iac_set(self.munir, "execute", {self.munir_subsystem: True})
         iac_set(self.histogrammer, "acquisition/run", True)
 
         # This task runs in the thread execution pool

--- a/control/src/hexitec/acquisition/processes/state.py
+++ b/control/src/hexitec/acquisition/processes/state.py
@@ -72,7 +72,7 @@ class State():
     def toggle_file_timestamp(self, enable: bool):
         """Set the file timestamp toggle to True or False.
         This adds a timestamp to the name of the file at time of acquisition start.
-        The format is: _YYMMDD_HHMMSS 
+        The format is: _YYYY-MM-DD_HH-MM-SS (ISO 8601)
         :param enable: boolean representing the state of the toggle
         """
         self.file_timestamp = bool(enable)
@@ -135,8 +135,6 @@ class State():
             self._stop_acquisition()
 
     def _start_acquisition(self):
-
-        
         # First, check if acquisition can work with data rate
         data_rate = self.configuration.calculate_estimated_data_rate()
         if data_rate >= 12.5:
@@ -174,7 +172,7 @@ class State():
         # Timestamp
         if self.file_timestamp:
             filename = iac_get(self.munir, f"subsystems/{self.munir_subsystem}/args/file_name")
-            stamp = datetime.now().strftime('%y%m%d_%H%M%S')
+            stamp = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
             filename = filename + "_" + stamp
             # self.file_name = filename
             iac_set(self.munir, f"subsystems/{self.munir_subsystem}/args/file_name", filename)

--- a/control/src/hexitec/acquisition/processes/state.py
+++ b/control/src/hexitec/acquisition/processes/state.py
@@ -120,7 +120,7 @@ class State():
         iac_set(self.munir, "execute", {'hexitec_mhz': True})
 
         # Configure how data should be sent
-        self.configuration._configure_histogramming()
+        iac_set(self.munir, "subsystems/hexitec_mhz/args/num_frames", self.configuration.number_of_timeframes)
         iac_set(self.histogrammer, "acquisition/run", True)
 
     def _stop_acquisition(self):

--- a/control/web/static/hexitec-react/src/EndpointTypes.tsx
+++ b/control/web/static/hexitec-react/src/EndpointTypes.tsx
@@ -354,6 +354,10 @@ export interface AcquisitionTypes extends ParamNode {
   state: {
     acquisition: {
       toggle: boolean;
+      progress_task: {
+        interval: number;
+        progress: number;
+      }
     };
     preview: {
       frames_per_hist: number;

--- a/control/web/static/hexitec-react/src/pages/Acquisition.tsx
+++ b/control/web/static/hexitec-react/src/pages/Acquisition.tsx
@@ -220,7 +220,6 @@ function Acquisition({ endpoint_url }: AcquisitionProps) {
                     label="File Name (without .h5 extension)">
                       <EndpointInput
                         endpoint={acquisitionEndpoint} fullpath="state/acquisition/file_name"
-                        type="text"
                         style={floatingInputStyle}
                       />
                   </FloatingLabel>
@@ -242,7 +241,6 @@ function Acquisition({ endpoint_url }: AcquisitionProps) {
                     label="File Path">
                       <EndpointInput
                         endpoint={acquisitionEndpoint} fullpath="state/acquisition/file_path"
-                        type="text"
                         style={floatingInputStyle}
                       />
                   </FloatingLabel>
@@ -251,7 +249,11 @@ function Acquisition({ endpoint_url }: AcquisitionProps) {
               <Row className="mt-3">
                 <Col>
                   <Form.Label>Acquisition Progress</Form.Label>
-                  <ProgressBar now={acquisitionProgress} label={acquisitionProgressLabel} />
+                  <ProgressBar
+                    now={acquisitionProgress ?? 0}
+                    label={acquisitionProgressLabel}
+                    variant={acquisitionProgress === 100 ? 'success' : undefined}
+                  />
                 </Col>
               </Row>
               <Row className="mt-3">

--- a/control/web/static/hexitec-react/src/pages/Acquisition.tsx
+++ b/control/web/static/hexitec-react/src/pages/Acquisition.tsx
@@ -18,11 +18,15 @@ function Acquisition({ endpoint_url }: AcquisitionProps) {
   const acquisitionData = acquisitionEndpoint?.data;
 
   const [triggerModeValue, setTriggerModeValue] = useState('software');
-  const [adTriggerModeValue, setAdTriggerModeValue] = useState('burst');
+  const [adTriggerModeValue, setAdTriggerModeValue] = useState('burst mode');
 
-  const estimatedDataRate = Number(acquisitionData?.config?.estimated_data_rate ?? 0);
+  const estimatedDataRate = acquisitionData?.config?.estimated_data_rate ?? 0;
   const rateTooHigh = estimatedDataRate > 12.5;
+
   const isAcquiring = acquisitionEndpoint?.data?.state?.acquisition?.toggle;
+  const acquisitionProgress = acquisitionEndpoint?.data?.state?.acquisition?.progress_task?.progress;
+  const acquisitionProgressLabel = acquisitionProgress?.toString() + '%'
+
   const acquisitionButtonDisabled = rateTooHigh && !isAcquiring;
   const acquisitionButtonVariant = isAcquiring ? 'danger' : rateTooHigh ? 'danger' : 'primary';
   const triggerModeRadios = [
@@ -30,9 +34,8 @@ function Acquisition({ endpoint_url }: AcquisitionProps) {
     { name: 'Software', value: 'software' }
   ];
   const adTriggerModeRadios = [
-    { name: 'Burst',  value: 'burst' },
-    { name: 'Continuous', value: 'continuous' },
-    { name: 'Step scan', value: 'step_scan' }
+    { name: 'Burst',  value: 'burst mode' },
+    { name: 'Step scan', value: 'step scan' }
   ];
   // your manual use of endpoint.put rather than the WithEndpoint components makes me sad :()
   const handleTriggerModeChange = (value: string) => {
@@ -60,12 +63,13 @@ function Acquisition({ endpoint_url }: AcquisitionProps) {
   const est_duration = ((acquisitionData?.config?.trigger?.frames_per_timeframe * acquisitionData?.config?.trigger?.number_of_timeframes) / 1000000);
 
   return (
+    
     <Container>
       <Row>
         {/* Trigger Settings */}
-        <Col md={6} className="mt-3">
+        <Col md={6} className="mt-3"> 
           <TitleCard title={<strong>Trigger Settings</strong>}>
-            <Row className="mt-3">
+            <Row>
               <ButtonGroup>
                 {triggerModeRadios.map((radio, idx) => (
                   <OverlayTrigger placement="top" overlay={radio.value === 'hardware' ? tooltips.acquisition.hardware : tooltips.acquisition.software}>
@@ -85,99 +89,51 @@ function Acquisition({ endpoint_url }: AcquisitionProps) {
                   </OverlayTrigger>
                 ))}
               </ButtonGroup>
-              {/* Show AD trigger mode options if hardware trigger mode is selected. needs centering */}
-              {triggerModeValue==='hardware' ? (
-                <Col>
-                  <Row className="mt-3">
-                    <ButtonGroup>
-                      {adTriggerModeRadios.map((radio, idx) => (
-                        <ToggleButton
-                          key={idx}
-                          className='equal-width-buttongroup'
-                          id={`ad-trigger-radio-${idx}`}
-                          type="radio"
-                          variant='outline-secondary'
-                          name="adTriggerModeRadio"
-                          value={radio.value}
-                          checked={adTriggerModeValue === radio.value}
-                          onChange={(e) => handleAdTriggerModeChange(e.currentTarget.value)}
-                        >
-                          {radio.name}
-                        </ToggleButton>
-                      ))}
-                    </ButtonGroup>
-                  </Row>
-                  <Row>
-                    {adTriggerModeValue === 'burst' && (
-                      <>
-                        <Col className="mt-3">
-                          <FloatingLabel label="Timeframes per trigger">
-                            <EndpointInput
-                              endpoint={acquisitionEndpoint} fullpath="config/trigger/number_of_timeframes"
-                              type="number"
-                              style={floatingInputStyle}
-                            />
-                          </FloatingLabel>
-                        </Col>
-                        <Col className="mt-3">
-                          <FloatingLabel label="Frames per timeframe">
-                            <EndpointInput
-                              endpoint={acquisitionEndpoint} fullpath="config/trigger/frames_per_timeframe"
-                              type="number"
-                              style={floatingInputStyle}
-                            />
-                          </FloatingLabel>
-                        </Col>
-                      </>
-                    )}
-                    {adTriggerModeValue === 'continuous' && (
-                      <Col className="mt-3">
-                        <p>In continuous mode, the detector acquires frames continuously, assigned to the current histogram time frame until the next trigger is received. Acquisition continues until end or aborted.</p>
-                      </Col>
-                    )}
-                    {adTriggerModeValue === 'step_scan' && (
-                      <>
-                        <Col className="mt-3">
-                          <FloatingLabel label="Frames per timeframe">
-                            <EndpointInput
-                              endpoint={acquisitionEndpoint} fullpath="config/trigger/frames_per_timeframe"
-                              type="number"
-                              style={floatingInputStyle}
-                            />
-                          </FloatingLabel>
-                        </Col>
-                        <Col className="mt-3">
-                          <p>In step scan mode, the detector will acquire a set number of frames (input) each time it receives a trigger. The detector will wait for the next trigger before acquiring the next set of frames.</p>
-                        </Col>
-                      </>
-                    )}
-                  </Row>
-                </Col>
-              ) : (
-                // show software trigger options if software trigger mode is selected: # timeframes, and frames per timeframe
-                <Col>
-                  <Row>
-                    <Col className="mt-3">
-                      <FloatingLabel label="# Timeframes">
-                        <EndpointInput
-                          endpoint={acquisitionEndpoint} fullpath="config/trigger/number_of_timeframes"
-                          type="number"
-                          style={floatingInputStyle}
-                        />
-                      </FloatingLabel>
-                    </Col>
-                    <Col className="mt-3">
-                      <FloatingLabel label="Frames per timeframe">
-                        <EndpointInput
-                          endpoint={acquisitionEndpoint} fullpath="config/trigger/frames_per_timeframe"
-                          type="number"
-                          style={floatingInputStyle}
-                        />
-                      </FloatingLabel>
-                    </Col>
-                  </Row>
-                </Col>
-              )}
+            </Row>
+            <Row>
+              <ButtonGroup className="mt-3">
+                {adTriggerModeRadios.map((radio, idx) => (
+                  <ToggleButton
+                    key={idx}
+                    className='equal-width-buttongroup'
+                    id={`ad-trigger-radio-${idx}`}
+                    type="radio"
+                    variant='outline-secondary'
+                    name="adTriggerModeRadio"
+                    value={radio.value}
+                    checked={adTriggerModeValue === radio.value}
+                    onChange={(e) => handleAdTriggerModeChange(e.currentTarget.value)}
+                  >
+                    {radio.name}
+                  </ToggleButton>
+                ))}
+              </ButtonGroup>
+            </Row>
+            <Row className="mt-3">
+              <Col>
+                <FloatingLabel label="Timeframes to write">
+                  <EndpointInput
+                    endpoint={acquisitionEndpoint} fullpath="config/trigger/number_of_timeframes"
+                    type="number"
+                    style={floatingInputStyle}
+                  />
+                </FloatingLabel>
+                <FloatingLabel label="Frames per timeframe" className="mt-2">
+                  <EndpointInput
+                    endpoint={acquisitionEndpoint} fullpath="config/trigger/frames_per_timeframe"
+                    type="number"
+                    style={floatingInputStyle}
+                  />
+                </FloatingLabel>
+                <FloatingLabel label="Timeframes per trigger" className="mt-2">
+                  <EndpointInput
+                    endpoint={acquisitionEndpoint} fullpath="config/trigger/timeframes_per_trigger"
+                    type="number"
+                    style={floatingInputStyle}
+                    disabled={triggerModeValue==='software' || !(adTriggerModeValue==='burst mode')}
+                  />
+                </FloatingLabel>
+              </Col>
             </Row>
             <Row className="mt-3">
               <label><strong>Summary</strong></label>
@@ -186,16 +142,10 @@ function Acquisition({ endpoint_url }: AcquisitionProps) {
               <Col sm={6}>
                 <Row>
                   <Col>
-                    <FloatingLabel label="# Histograms">
+                    <FloatingLabel label="Histograms per Acquisition">
                       <Form.Control
                         type="text"
-                        value={
-                          triggerModeValue === 'software' 
-                            ? acquisitionData?.config?.trigger?.number_of_timeframes.toString()
-                            : adTriggerModeValue === 'burst' 
-                              ? acquisitionData?.config?.trigger?.number_of_timeframes.toString() + ' per trigger'
-                              : '1 per trigger'
-                        }
+                        value={acquisitionData?.config?.trigger?.number_of_timeframes.toString()}
                         readOnly
                         style={floatingLabelStyle}
                       />
@@ -204,6 +154,8 @@ function Acquisition({ endpoint_url }: AcquisitionProps) {
                 </Row>
                 <Row>
                   <Col>
+                    {/* If in software, this is a predictable outcome. 
+                    In hardware mode, it's basically a minimum as triggers may have gaps inbetween */}
                     <OverlayTrigger placement="top" overlay={tooltips.acquisition.est_duration}>
                       <FloatingLabel label="Est. Duration (s)">
                         <Form.Control
@@ -211,11 +163,7 @@ function Acquisition({ endpoint_url }: AcquisitionProps) {
                           value={
                             triggerModeValue === 'software'
                               ? est_duration.toString()
-                              : adTriggerModeValue === 'burst'
-                                ? est_duration.toString() + ' per trigger'
-                                : adTriggerModeValue === 'continuous'
-                                  ? '-'
-                                  : (1 / (acquisitionData?.config?.trigger?.frames_per_timeframe || 1)).toFixed(6) + ' per trigger'
+                              : est_duration.toString() + ' minimum'
                           }
                           readOnly
                           style={floatingLabelStyle}
@@ -247,11 +195,7 @@ function Acquisition({ endpoint_url }: AcquisitionProps) {
                     <FloatingLabel label="Total Storage">
                       <Form.Control
                         type="text"
-                        value={
-                          triggerModeValue === 'hardware' ?
-                            acquisitionData?.config?.estimated_data_rate + ' GB/s' :
-                            acquisitionData?.config?.estimated_data_rate * est_duration + ' GB'
-                        }
+                        value={acquisitionData?.config?.estimated_data_rate * est_duration + ' GB'}
                         readOnly
                         style={floatingLabelStyle}
                         className={rateTooHigh ? 'border border-danger text-danger bg-danger bg-opacity-10' : ''}
@@ -262,7 +206,6 @@ function Acquisition({ endpoint_url }: AcquisitionProps) {
               </Col>
             </Row>
           </TitleCard>
-
         </Col>
 
         {/* Acquisition Status */}
@@ -301,7 +244,7 @@ function Acquisition({ endpoint_url }: AcquisitionProps) {
               <Row className="mb-3">
                 <Col>
                   <Form.Label>Acquisition Progress</Form.Label>
-                  <ProgressBar now={0} label="0%" />
+                  <ProgressBar now={acquisitionProgress} label={acquisitionProgressLabel} />
                 </Col>
               </Row>
               <Row className="mb-3">

--- a/control/web/static/hexitec-react/src/pages/Acquisition.tsx
+++ b/control/web/static/hexitec-react/src/pages/Acquisition.tsx
@@ -1,4 +1,4 @@
-import { EndpointButton, EndpointInput, TitleCard, useAdapterEndpoint } from 'odin-react';
+import { EndpointButton, EndpointCheckbox, EndpointInput, TitleCard, useAdapterEndpoint } from 'odin-react';
 import { useState } from 'react';
 import { ButtonGroup, Card, Col, Container, FloatingLabel, Form, OverlayTrigger, ProgressBar, Row, ToggleButton } from 'react-bootstrap';
 import type { AcquisitionTypes, MunirTypes } from '../EndpointTypes';
@@ -214,40 +214,47 @@ function Acquisition({ endpoint_url }: AcquisitionProps) {
             <Card.Header><strong>Acquisition Status</strong></Card.Header>
             <Card.Body>
               {/* File Name */}
-              <Row className="mb-3">
+              <Row>
                 <Col>
                   <FloatingLabel 
                     label="File Name (without .h5 extension)">
                       <EndpointInput
-                        endpoint={munirEndpoint} fullpath="subsystems/hexitec_mhz/args/file_name"
+                        endpoint={acquisitionEndpoint} fullpath="state/acquisition/file_name"
                         type="text"
                         style={floatingInputStyle}
                       />
                   </FloatingLabel>
-
+                </Col>
+              </Row>
+              <Row classname="mt-2">
+                <Col>
+                  <EndpointCheckbox
+                    endpoint={acquisitionEndpoint} fullpath="state/acquisition/add_timestamp"
+                    label="Add timestamp to file"
+                  />
                 </Col>
               </Row>
 
               {/* (File Path) */}
-              <Row className="mb-3">
+              <Row className="mt-3">
                 <Col>
                   <FloatingLabel 
                     label="File Path">
                       <EndpointInput
-                        endpoint={munirEndpoint} fullpath="subsystems/hexitec_mhz/args/file_path"
+                        endpoint={acquisitionEndpoint} fullpath="state/acquisition/file_path"
                         type="text"
                         style={floatingInputStyle}
                       />
                   </FloatingLabel>
                 </Col>
               </Row>
-              <Row className="mb-3">
+              <Row className="mt-3">
                 <Col>
                   <Form.Label>Acquisition Progress</Form.Label>
                   <ProgressBar now={acquisitionProgress} label={acquisitionProgressLabel} />
                 </Col>
               </Row>
-              <Row className="mb-3">
+              <Row className="mt-3">
                 <Col>
                   <EndpointButton
                     endpoint={acquisitionEndpoint}


### PR DESCRIPTION
This pull request closes two related issues concerning the Acquisition page and logic.

Closes #25: there is a progress bar that counts based on munir's frames written against the target number of frames. Right now, this does not support open-ended acquisitions but that will be added when those features are added.
Closes #26: a timestamp can be added to filenames in the format `_YYYY-MM-DD_HH-MM-SS` based on when the acquisition is started.

+ Filename/path convenience functions in acquisition.state
+ All acquisitions have a frame target for now
- Continuous mode is subsequently gone
~ Acquisition page rework for simplicity
+ 'Timeframes per trigger' option added for burst mode specifically